### PR TITLE
Little Chanded

### DIFF
--- a/nrf24l01.c
+++ b/nrf24l01.c
@@ -511,7 +511,7 @@ NRF_RESULT NRF_SetTXAddress(nrf24L01_Dev* dev, uint8_t* address) {
 }
 
 NRF_RESULT NRF_SetRXPayloadWidth_P0(nrf24L01_Dev* dev, uint8_t width) {
-	width &= 0x2F;
+	width &= 0x3F;
 	if (NRF_WriteRegister(dev, NRF_RX_PW_P0, &width) != NRF_OK) {
 		return NRF_ERROR;
 	}

--- a/nrf24l01.c
+++ b/nrf24l01.c
@@ -511,7 +511,7 @@ NRF_RESULT NRF_SetTXAddress(nrf24L01_Dev* dev, uint8_t* address) {
 }
 
 NRF_RESULT NRF_SetRXPayloadWidth_P0(nrf24L01_Dev* dev, uint8_t width) {
-	width &= 0x3F;
+	width &= 0x2F;
 	if (NRF_WriteRegister(dev, NRF_RX_PW_P0, &width) != NRF_OK) {
 		return NRF_ERROR;
 	}

--- a/nrf24l01.c
+++ b/nrf24l01.c
@@ -1,23 +1,23 @@
 #include "nrf24l01.h"
 
-static void NRF_CS_SETPIN(NRF24L01* dev) {
+static void NRF_CS_SETPIN(nrf24L01_Dev* dev) {
 	HAL_GPIO_WritePin(dev->NRF_CSN_GPIOx, dev->NRF_CSN_GPIO_PIN,
 					  GPIO_PIN_RESET);
 }
 
-static void NRF_CS_RESETPIN(NRF24L01* dev) {
+static void NRF_CS_RESETPIN(nrf24L01_Dev* dev) {
 	HAL_GPIO_WritePin(dev->NRF_CSN_GPIOx, dev->NRF_CSN_GPIO_PIN, GPIO_PIN_SET);
 }
 
-static void NRF_CE_SETPIN(NRF24L01* dev) {
+static void NRF_CE_SETPIN(nrf24L01_Dev* dev) {
 	HAL_GPIO_WritePin(dev->NRF_CE_GPIOx, dev->NRF_CE_GPIO_PIN, GPIO_PIN_SET);
 }
 
-static void NRF_CE_RESETPIN(NRF24L01* dev) {
+static void NRF_CE_RESETPIN(nrf24L01_Dev* dev) {
 	HAL_GPIO_WritePin(dev->NRF_CE_GPIOx, dev->NRF_CE_GPIO_PIN, GPIO_PIN_RESET);
 }
 
-NRF_RESULT NRF_SetupGPIO(NRF24L01* dev) {
+NRF_RESULT NRF_SetupGPIO(nrf24L01_Dev* dev) {
 
 	GPIO_InitTypeDef GPIO_InitStructure;
 
@@ -48,7 +48,7 @@ NRF_RESULT NRF_SetupGPIO(NRF24L01* dev) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_Init(NRF24L01* dev) {
+NRF_RESULT NRF_Init(nrf24L01_Dev* dev) {
 
 	NRF_SetupGPIO(dev);
 
@@ -86,7 +86,7 @@ NRF_RESULT NRF_Init(NRF24L01* dev) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SendCommand(NRF24L01* dev, uint8_t cmd, uint8_t* tx, uint8_t* rx,
+NRF_RESULT NRF_SendCommand(nrf24L01_Dev* dev, uint8_t cmd, uint8_t* tx, uint8_t* rx,
 		uint8_t len) {
 	uint8_t myTX[len + 1];
 	uint8_t myRX[len + 1];
@@ -113,7 +113,7 @@ NRF_RESULT NRF_SendCommand(NRF24L01* dev, uint8_t cmd, uint8_t* tx, uint8_t* rx,
 	return NRF_OK;
 }
 
-void NRF_IRQ_Handler(NRF24L01* dev) {
+void NRF_IRQ_Handler(nrf24L01_Dev* dev) {
 	uint8_t status = 0;
 	if (NRF_ReadRegister(dev, NRF_STATUS, &status) != NRF_OK) {
 		return;
@@ -159,7 +159,7 @@ void NRF_IRQ_Handler(NRF24L01* dev) {
 	}
 }
 
-NRF_RESULT NRF_ReadRegister(NRF24L01* dev, uint8_t reg, uint8_t* data) {
+NRF_RESULT NRF_ReadRegister(nrf24L01_Dev* dev, uint8_t reg, uint8_t* data) {
 	uint8_t tx = 0;
 	if (NRF_SendCommand(dev, NRF_CMD_R_REGISTER | reg, &tx, data, 1)
 			!= NRF_OK) {
@@ -168,7 +168,7 @@ NRF_RESULT NRF_ReadRegister(NRF24L01* dev, uint8_t reg, uint8_t* data) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_WriteRegister(NRF24L01* dev, uint8_t reg, uint8_t* data) {
+NRF_RESULT NRF_WriteRegister(nrf24L01_Dev* dev, uint8_t reg, uint8_t* data) {
 	uint8_t rx = 0;
 	if (NRF_SendCommand(dev, NRF_CMD_W_REGISTER | reg, data, &rx, 1)
 			!= NRF_OK) {
@@ -177,7 +177,7 @@ NRF_RESULT NRF_WriteRegister(NRF24L01* dev, uint8_t reg, uint8_t* data) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_ReadRXPayload(NRF24L01* dev, uint8_t* data) {
+NRF_RESULT NRF_ReadRXPayload(nrf24L01_Dev* dev, uint8_t* data) {
 	uint8_t tx[dev->PayloadLength];
 	if (NRF_SendCommand(dev, NRF_CMD_R_RX_PAYLOAD, tx, data, dev->PayloadLength)
 			!= NRF_OK) {
@@ -186,7 +186,7 @@ NRF_RESULT NRF_ReadRXPayload(NRF24L01* dev, uint8_t* data) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_WriteTXPayload(NRF24L01* dev, uint8_t* data) {
+NRF_RESULT NRF_WriteTXPayload(nrf24L01_Dev* dev, uint8_t* data) {
 	uint8_t rx[dev->PayloadLength];
 	if (NRF_SendCommand(dev, NRF_CMD_W_TX_PAYLOAD, data, rx, dev->PayloadLength)
 			!= NRF_OK) {
@@ -195,7 +195,7 @@ NRF_RESULT NRF_WriteTXPayload(NRF24L01* dev, uint8_t* data) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_FlushTX(NRF24L01* dev) {
+NRF_RESULT NRF_FlushTX(nrf24L01_Dev* dev) {
 	uint8_t rx = 0;
 	uint8_t tx = 0;
 	if (NRF_SendCommand(dev, NRF_CMD_FLUSH_TX, &tx, &rx, 0) != NRF_OK) {
@@ -204,7 +204,7 @@ NRF_RESULT NRF_FlushTX(NRF24L01* dev) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_FlushRX(NRF24L01* dev) {
+NRF_RESULT NRF_FlushRX(nrf24L01_Dev* dev) {
 	uint8_t rx = 0;
 	uint8_t tx = 0;
 	if (NRF_SendCommand(dev, NRF_CMD_FLUSH_RX, &tx, &rx, 0) != NRF_OK) {
@@ -213,7 +213,7 @@ NRF_RESULT NRF_FlushRX(NRF24L01* dev) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SetDataRate(NRF24L01* dev, NRF_DATA_RATE rate) {
+NRF_RESULT NRF_SetDataRate(nrf24L01_Dev* dev, NRF_DATA_RATE rate) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_RF_SETUP, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -235,7 +235,7 @@ NRF_RESULT NRF_SetDataRate(NRF24L01* dev, NRF_DATA_RATE rate) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SetTXPower(NRF24L01* dev, NRF_TX_PWR pwr) {
+NRF_RESULT NRF_SetTXPower(nrf24L01_Dev* dev, NRF_TX_PWR pwr) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_RF_SETUP, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -248,7 +248,7 @@ NRF_RESULT NRF_SetTXPower(NRF24L01* dev, NRF_TX_PWR pwr) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SetCCW(NRF24L01* dev, uint8_t activate) {
+NRF_RESULT NRF_SetCCW(nrf24L01_Dev* dev, uint8_t activate) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_RF_SETUP, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -266,7 +266,7 @@ NRF_RESULT NRF_SetCCW(NRF24L01* dev, uint8_t activate) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_ClearInterrupts(NRF24L01* dev) {
+NRF_RESULT NRF_ClearInterrupts(nrf24L01_Dev* dev) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_STATUS, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -280,7 +280,7 @@ NRF_RESULT NRF_ClearInterrupts(NRF24L01* dev) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SetRFChannel(NRF24L01* dev, uint8_t ch) {
+NRF_RESULT NRF_SetRFChannel(nrf24L01_Dev* dev, uint8_t ch) {
 	ch &= 0x7F;
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_RF_CH, &reg) != NRF_OK) {
@@ -295,7 +295,7 @@ NRF_RESULT NRF_SetRFChannel(NRF24L01* dev, uint8_t ch) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SetRetransmittionCount(NRF24L01* dev, uint8_t count) {
+NRF_RESULT NRF_SetRetransmittionCount(nrf24L01_Dev* dev, uint8_t count) {
 	count &= 0x0F;
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_SETUP_RETR, &reg) != NRF_OK) {
@@ -311,7 +311,7 @@ NRF_RESULT NRF_SetRetransmittionCount(NRF24L01* dev, uint8_t count) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SetRetransmittionDelay(NRF24L01* dev, uint8_t delay) {
+NRF_RESULT NRF_SetRetransmittionDelay(nrf24L01_Dev* dev, uint8_t delay) {
 	delay &= 0x0F;
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_SETUP_RETR, &reg) != NRF_OK) {
@@ -327,7 +327,7 @@ NRF_RESULT NRF_SetRetransmittionDelay(NRF24L01* dev, uint8_t delay) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SetAddressWidth(NRF24L01* dev, NRF_ADDR_WIDTH width) {
+NRF_RESULT NRF_SetAddressWidth(nrf24L01_Dev* dev, NRF_ADDR_WIDTH width) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_SETUP_AW, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -342,7 +342,7 @@ NRF_RESULT NRF_SetAddressWidth(NRF24L01* dev, NRF_ADDR_WIDTH width) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_EnableRXPipe(NRF24L01* dev, uint8_t pipe) {
+NRF_RESULT NRF_EnableRXPipe(nrf24L01_Dev* dev, uint8_t pipe) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_EN_RXADDR, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -356,7 +356,7 @@ NRF_RESULT NRF_EnableRXPipe(NRF24L01* dev, uint8_t pipe) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_EnableAutoAcknowledgement(NRF24L01* dev, uint8_t pipe) {
+NRF_RESULT NRF_EnableAutoAcknowledgement(nrf24L01_Dev* dev, uint8_t pipe) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_EN_AA, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -370,7 +370,7 @@ NRF_RESULT NRF_EnableAutoAcknowledgement(NRF24L01* dev, uint8_t pipe) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_EnableCRC(NRF24L01* dev, uint8_t activate) {
+NRF_RESULT NRF_EnableCRC(nrf24L01_Dev* dev, uint8_t activate) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_CONFIG, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -388,7 +388,7 @@ NRF_RESULT NRF_EnableCRC(NRF24L01* dev, uint8_t activate) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SetCRCWidth(NRF24L01* dev, NRF_CRC_WIDTH width) {
+NRF_RESULT NRF_SetCRCWidth(nrf24L01_Dev* dev, NRF_CRC_WIDTH width) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_CONFIG, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -406,7 +406,7 @@ NRF_RESULT NRF_SetCRCWidth(NRF24L01* dev, NRF_CRC_WIDTH width) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_PowerUp(NRF24L01* dev, uint8_t powerUp) {
+NRF_RESULT NRF_PowerUp(nrf24L01_Dev* dev, uint8_t powerUp) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_CONFIG, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -424,7 +424,7 @@ NRF_RESULT NRF_PowerUp(NRF24L01* dev, uint8_t powerUp) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_RXTXControl(NRF24L01* dev, NRF_TXRX_STATE rx) {
+NRF_RESULT NRF_RXTXControl(nrf24L01_Dev* dev, NRF_TXRX_STATE rx) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_CONFIG, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -442,7 +442,7 @@ NRF_RESULT NRF_RXTXControl(NRF24L01* dev, NRF_TXRX_STATE rx) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_EnableRXDataReadyIRQ(NRF24L01* dev, uint8_t activate) {
+NRF_RESULT NRF_EnableRXDataReadyIRQ(nrf24L01_Dev* dev, uint8_t activate) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_CONFIG, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -460,7 +460,7 @@ NRF_RESULT NRF_EnableRXDataReadyIRQ(NRF24L01* dev, uint8_t activate) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_EnableTXDataSentIRQ(NRF24L01* dev, uint8_t activate) {
+NRF_RESULT NRF_EnableTXDataSentIRQ(nrf24L01_Dev* dev, uint8_t activate) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_CONFIG, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -476,7 +476,7 @@ NRF_RESULT NRF_EnableTXDataSentIRQ(NRF24L01* dev, uint8_t activate) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_EnableMaxRetransmitIRQ(NRF24L01* dev, uint8_t activate) {
+NRF_RESULT NRF_EnableMaxRetransmitIRQ(nrf24L01_Dev* dev, uint8_t activate) {
 	uint8_t reg = 0;
 	if (NRF_ReadRegister(dev, NRF_CONFIG, &reg) != NRF_OK) {
 		return NRF_ERROR;
@@ -492,7 +492,7 @@ NRF_RESULT NRF_EnableMaxRetransmitIRQ(NRF24L01* dev, uint8_t activate) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SetRXAddress_P0(NRF24L01* dev, uint8_t* address) {
+NRF_RESULT NRF_SetRXAddress_P0(nrf24L01_Dev* dev, uint8_t* address) {
 	uint8_t rx[5];
 	if (NRF_SendCommand(dev, NRF_CMD_W_REGISTER | NRF_RX_ADDR_P0, address, rx,
 			5) != NRF_OK) {
@@ -501,7 +501,7 @@ NRF_RESULT NRF_SetRXAddress_P0(NRF24L01* dev, uint8_t* address) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SetTXAddress(NRF24L01* dev, uint8_t* address) {
+NRF_RESULT NRF_SetTXAddress(nrf24L01_Dev* dev, uint8_t* address) {
 	uint8_t rx[5];
 	if (NRF_SendCommand(dev, NRF_CMD_W_REGISTER | NRF_TX_ADDR, address, rx, 5)
 			!= NRF_OK) {
@@ -510,7 +510,7 @@ NRF_RESULT NRF_SetTXAddress(NRF24L01* dev, uint8_t* address) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SetRXPayloadWidth_P0(NRF24L01* dev, uint8_t width) {
+NRF_RESULT NRF_SetRXPayloadWidth_P0(nrf24L01_Dev* dev, uint8_t width) {
 	width &= 0x3F;
 	if (NRF_WriteRegister(dev, NRF_RX_PW_P0, &width) != NRF_OK) {
 		return NRF_ERROR;
@@ -518,7 +518,7 @@ NRF_RESULT NRF_SetRXPayloadWidth_P0(NRF24L01* dev, uint8_t width) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_SendPacket(NRF24L01* dev, uint8_t* data) {
+NRF_RESULT NRF_SendPacket(nrf24L01_Dev* dev, uint8_t* data) {
 
 	dev->BUSY_FLAG = 1;
 
@@ -532,7 +532,7 @@ NRF_RESULT NRF_SendPacket(NRF24L01* dev, uint8_t* data) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_ReceivePacket(NRF24L01* dev, uint8_t* data) {
+NRF_RESULT NRF_ReceivePacket(nrf24L01_Dev* dev, uint8_t* data) {
 
 	dev->BUSY_FLAG = 1;
 
@@ -550,7 +550,7 @@ NRF_RESULT NRF_ReceivePacket(NRF24L01* dev, uint8_t* data) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_PushPacket(NRF24L01* dev, uint8_t* data) {
+NRF_RESULT NRF_PushPacket(nrf24L01_Dev* dev, uint8_t* data) {
 
 	if(dev->BUSY_FLAG==1) {
 		NRF_FlushTX(dev);
@@ -565,7 +565,7 @@ NRF_RESULT NRF_PushPacket(NRF24L01* dev, uint8_t* data) {
 	return NRF_OK;
 }
 
-NRF_RESULT NRF_PullPacket(NRF24L01* dev, uint8_t* data) {
+NRF_RESULT NRF_PullPacket(nrf24L01_Dev* dev, uint8_t* data) {
 
 	int i = 0;
 	for (i = 0; i < dev->PayloadLength; i++) {

--- a/nrf24l01.c
+++ b/nrf24l01.c
@@ -2,7 +2,7 @@
 
 void NRF_CS_ENABLE(NRF24L01* dev) {
 	HAL_GPIO_WritePin(dev->NRF_CSN_GPIOx, dev->NRF_CSN_GPIO_PIN,
-			GPIO_PIN_RESET);
+					  GPIO_PIN_RESET);
 }
 
 void NRF_CS_DISABLE(NRF24L01* dev) {
@@ -38,7 +38,7 @@ NRF_RESULT NRF_SetupGPIO(NRF24L01* dev) {
 
 	/* Enable and set EXTI Line Interrupt to the given priority */
 	HAL_NVIC_SetPriority(dev->NRF_IRQn, dev->NRF_IRQ_preempt_priority,
-			dev->NRF_IRQ_sub_priority);
+						 dev->NRF_IRQ_sub_priority);
 	HAL_NVIC_EnableIRQ(dev->NRF_IRQn);
 	// end IRQ pin
 
@@ -56,7 +56,7 @@ NRF_RESULT NRF_Init(NRF24L01* dev) {
 
 	uint8_t config=0;
 
-	while((config&2)==0){	// wait for powerup
+	while((config&2)==0) {	// wait for powerup
 		NRF_ReadRegister(dev,NRF_CONFIG,&config);
 	}
 
@@ -527,7 +527,7 @@ NRF_RESULT NRF_SendPacket(NRF24L01* dev, uint8_t* data) {
 	NRF_WriteTXPayload(dev, data);
 	NRF_CE_ENABLE(dev);
 
-	while (dev->BUSY_FLAG == 1);	// wait for end of transmittion
+	while (dev->BUSY_FLAG == 1) {;}	// wait for end of transmittion
 
 	return NRF_OK;
 }
@@ -540,7 +540,7 @@ NRF_RESULT NRF_ReceivePacket(NRF24L01* dev, uint8_t* data) {
 	NRF_RXTXControl(dev, NRF_STATE_RX);
 	NRF_CE_ENABLE(dev);
 
-	while (dev->BUSY_FLAG == 1);	// wait for reception
+	while (dev->BUSY_FLAG == 1) {;}	// wait for reception
 
 	int i = 0;
 	for (i = 0; i < dev->PayloadLength; i++) {
@@ -552,9 +552,9 @@ NRF_RESULT NRF_ReceivePacket(NRF24L01* dev, uint8_t* data) {
 
 NRF_RESULT NRF_PushPacket(NRF24L01* dev, uint8_t* data) {
 
-	if(dev->BUSY_FLAG==1){
+	if(dev->BUSY_FLAG==1) {
 		NRF_FlushTX(dev);
-	}else{
+	} else {
 		dev->BUSY_FLAG = 1;
 	}
 	NRF_CE_DISABLE(dev);

--- a/nrf24l01.h
+++ b/nrf24l01.h
@@ -78,23 +78,42 @@ typedef enum{
 } NRF_TXRX_STATE;
 
 typedef struct {
-    SPI_HandleTypeDef* 	spi;
+
+    /* nrf24L01 Configuration Parameter 
+       PayloadLength   : maximum is 32 Bytes
+       RetransmitCount : can be 0~15 times
+       RetransmitDelay : 0[250uS]~0x0F(4000us), LSB:250us
+    */
     NRF_DATA_RATE 		DATA_RATE;
-    uint8_t				RF_CHANNEL;
-    uint8_t				PayloadLength;
-    uint8_t				RetransmitCount;
-    uint8_t				RetransmitDelay;
     NRF_TX_PWR			TX_POWER;
-    uint8_t*			RX_ADDRESS;
-    uint8_t*			TX_ADDRESS;
     NRF_CRC_WIDTH		CRC_WIDTH;
     NRF_ADDR_WIDTH		ADDR_WIDTH;
     NRF_TXRX_STATE		STATE;
+    uint8_t				PayloadLength;
+    uint8_t				RetransmitCount;
+    uint8_t				RetransmitDelay;
+
     uint8_t				BUSY_FLAG;
 
+    /* Usr interface, Rx/Tx Buffer */
     uint8_t*			RX_BUFFER;
     uint8_t*			TX_BUFFER;
 
+    /* nrf24L01 transmit/recive freq define */
+    /* channel can be 0~127 */
+    uint8_t				RF_CHANNEL;
+
+    /* nrf24L01 Tx/Rx address
+       Pipe [0:1] has maximum 5 Bytes address
+       Pipe [2:5] has 3 Bytes address
+    */
+    uint8_t*			RX_ADDRESS;
+    uint8_t*			TX_ADDRESS;
+
+    /* STM32 SPI Peripheral HAL handle */
+    SPI_HandleTypeDef*  spi;
+
+    /* STM32 GPIO/EXTI Peripheral Parameter */
     GPIO_TypeDef*		NRF_CSN_GPIOx;	// CSN pin
     uint16_t			NRF_CSN_GPIO_PIN;
 

--- a/nrf24l01.h
+++ b/nrf24l01.h
@@ -107,7 +107,7 @@ typedef struct {
     uint8_t				NRF_IRQ_preempt_priority;
     uint8_t				NRF_IRQ_sub_priority;
 
-} NRF24L01;
+} nrf24L01_Dev;
 
 typedef enum {
     NRF_OK,
@@ -116,70 +116,70 @@ typedef enum {
 
 
 /* Initialization routine */
-NRF_RESULT NRF_Init(NRF24L01* dev);
+NRF_RESULT NRF_Init(nrf24L01_Dev* dev);
 
 /* EXTI Interrupt Handler */
-void NRF_IRQ_Handler(NRF24L01* dev);
+void NRF_IRQ_Handler(nrf24L01_Dev* dev);
 
 /* Blocking Data Sending / Receiving FXs */
-NRF_RESULT NRF_SendPacket(NRF24L01* dev,uint8_t* data);
-NRF_RESULT NRF_ReceivePacket(NRF24L01* dev,uint8_t* data);
+NRF_RESULT NRF_SendPacket(nrf24L01_Dev* dev,uint8_t* data);
+NRF_RESULT NRF_ReceivePacket(nrf24L01_Dev* dev,uint8_t* data);
 
 /* Non-Blocking Data Sending / Receiving FXs */
-NRF_RESULT NRF_PushPacket(NRF24L01* dev,uint8_t* data);
-NRF_RESULT NRF_PullPacket(NRF24L01* dev,uint8_t* data);
+NRF_RESULT NRF_PushPacket(nrf24L01_Dev* dev,uint8_t* data);
+NRF_RESULT NRF_PullPacket(nrf24L01_Dev* dev,uint8_t* data);
 
 /* LOW LEVEL STUFF (you don't have to look in here...)*/
-NRF_RESULT NRF_SendCommand(NRF24L01* dev, uint8_t cmd, uint8_t* tx,uint8_t* rx,uint8_t len);
+NRF_RESULT NRF_SendCommand(nrf24L01_Dev* dev, uint8_t cmd, uint8_t* tx,uint8_t* rx,uint8_t len);
 /* CMD */
-NRF_RESULT NRF_ReadRegister(NRF24L01* dev,uint8_t reg, uint8_t* data);
-NRF_RESULT NRF_WriteRegister(NRF24L01* dev,uint8_t reg, uint8_t* data);
-NRF_RESULT NRF_ReadRXPayload(NRF24L01* dev,uint8_t* data);
-NRF_RESULT NRF_WriteTXPayload(NRF24L01* dev,uint8_t* data);
-NRF_RESULT NRF_FlushTX(NRF24L01* dev);
-NRF_RESULT NRF_FlushRX(NRF24L01* dev);
+NRF_RESULT NRF_ReadRegister(nrf24L01_Dev* dev,uint8_t reg, uint8_t* data);
+NRF_RESULT NRF_WriteRegister(nrf24L01_Dev* dev,uint8_t reg, uint8_t* data);
+NRF_RESULT NRF_ReadRXPayload(nrf24L01_Dev* dev,uint8_t* data);
+NRF_RESULT NRF_WriteTXPayload(nrf24L01_Dev* dev,uint8_t* data);
+NRF_RESULT NRF_FlushTX(nrf24L01_Dev* dev);
+NRF_RESULT NRF_FlushRX(nrf24L01_Dev* dev);
 
 /* RF_SETUP */
-NRF_RESULT NRF_SetDataRate(NRF24L01* dev,NRF_DATA_RATE rate);
-NRF_RESULT NRF_SetTXPower(NRF24L01* dev,NRF_TX_PWR pwr);
-NRF_RESULT NRF_SetCCW(NRF24L01* dev,uint8_t activate);
+NRF_RESULT NRF_SetDataRate(nrf24L01_Dev* dev,NRF_DATA_RATE rate);
+NRF_RESULT NRF_SetTXPower(nrf24L01_Dev* dev,NRF_TX_PWR pwr);
+NRF_RESULT NRF_SetCCW(nrf24L01_Dev* dev,uint8_t activate);
 
 /* STATUS */
-NRF_RESULT NRF_ClearInterrupts(NRF24L01* dev);
+NRF_RESULT NRF_ClearInterrupts(nrf24L01_Dev* dev);
 
 /* RF_CH */
-NRF_RESULT NRF_SetRFChannel(NRF24L01* dev,uint8_t ch);
+NRF_RESULT NRF_SetRFChannel(nrf24L01_Dev* dev,uint8_t ch);
 
 /* SETUP_RETR */
-NRF_RESULT NRF_SetRetransmittionCount(NRF24L01* dev,uint8_t count);
-NRF_RESULT NRF_SetRetransmittionDelay(NRF24L01* dev,uint8_t delay);
+NRF_RESULT NRF_SetRetransmittionCount(nrf24L01_Dev* dev,uint8_t count);
+NRF_RESULT NRF_SetRetransmittionDelay(nrf24L01_Dev* dev,uint8_t delay);
 
 /* SETUP_AW */
-NRF_RESULT NRF_SetAddressWidth(NRF24L01* dev,NRF_ADDR_WIDTH width);
+NRF_RESULT NRF_SetAddressWidth(nrf24L01_Dev* dev,NRF_ADDR_WIDTH width);
 
 /* EN_RXADDR */
-NRF_RESULT NRF_EnableRXPipe(NRF24L01* dev,uint8_t pipe);
+NRF_RESULT NRF_EnableRXPipe(nrf24L01_Dev* dev,uint8_t pipe);
 
 /* EN_AA */
-NRF_RESULT NRF_EnableAutoAcknowledgement(NRF24L01* dev,uint8_t pipe);
+NRF_RESULT NRF_EnableAutoAcknowledgement(nrf24L01_Dev* dev,uint8_t pipe);
 
 /* CONFIG */
-NRF_RESULT NRF_EnableCRC(NRF24L01* dev,uint8_t activate);
-NRF_RESULT NRF_SetCRCWidth(NRF24L01* dev,NRF_CRC_WIDTH width);
-NRF_RESULT NRF_PowerUp(NRF24L01* dev,uint8_t powerUp);
-NRF_RESULT NRF_RXTXControl(NRF24L01* dev,NRF_TXRX_STATE rx);
-NRF_RESULT NRF_EnableRXDataReadyIRQ(NRF24L01* dev,uint8_t activate);
-NRF_RESULT NRF_EnableTXDataSentIRQ(NRF24L01* dev,uint8_t activate);
-NRF_RESULT NRF_EnableMaxRetransmitIRQ(NRF24L01* dev,uint8_t activate);
+NRF_RESULT NRF_EnableCRC(nrf24L01_Dev* dev,uint8_t activate);
+NRF_RESULT NRF_SetCRCWidth(nrf24L01_Dev* dev,NRF_CRC_WIDTH width);
+NRF_RESULT NRF_PowerUp(nrf24L01_Dev* dev,uint8_t powerUp);
+NRF_RESULT NRF_RXTXControl(nrf24L01_Dev* dev,NRF_TXRX_STATE rx);
+NRF_RESULT NRF_EnableRXDataReadyIRQ(nrf24L01_Dev* dev,uint8_t activate);
+NRF_RESULT NRF_EnableTXDataSentIRQ(nrf24L01_Dev* dev,uint8_t activate);
+NRF_RESULT NRF_EnableMaxRetransmitIRQ(nrf24L01_Dev* dev,uint8_t activate);
 
 /* RX_ADDR_P0 */
-NRF_RESULT NRF_SetRXAddress_P0(NRF24L01* dev,uint8_t* address);	// 5bytes of address
+NRF_RESULT NRF_SetRXAddress_P0(nrf24L01_Dev* dev,uint8_t* address);	// 5bytes of address
 
 /* TX_ADDR */
-NRF_RESULT NRF_SetTXAddress(NRF24L01* dev,uint8_t* address);	// 5bytes of address
+NRF_RESULT NRF_SetTXAddress(nrf24L01_Dev* dev,uint8_t* address);	// 5bytes of address
 
 /* RX_PW_P0 */
-NRF_RESULT NRF_SetRXPayloadWidth_P0(NRF24L01* dev,uint8_t width);
+NRF_RESULT NRF_SetRXPayloadWidth_P0(nrf24L01_Dev* dev,uint8_t width);
 
 /* FEATURE */
 

--- a/nrf24l01.h
+++ b/nrf24l01.h
@@ -2,6 +2,7 @@
 #define NRF24L01_H_
 
 #include "stm32f4xx_hal.h"
+#include <stdint.h>
 
 /* Registers */
 #define NRF_CONFIG		0x00
@@ -47,70 +48,70 @@
 
 #define NRF_SPI_TIMEOUT	100000
 
-typedef enum{
-	NRF_DATA_RATE_250KBPS=1,
-	NRF_DATA_RATE_1MBPS=0,
-	NRF_DATA_RATE_2MBPS=2
+typedef enum {
+    NRF_DATA_RATE_250KBPS = 1,
+    NRF_DATA_RATE_1MBPS   = 0,
+    NRF_DATA_RATE_2MBPS   = 2
 } NRF_DATA_RATE;
 
-typedef enum{
-	NRF_TX_PWR_M18dBm=0,
-	NRF_TX_PWR_M12dBm=1,
-	NRF_TX_PWR_M6dBm=2,
-	NRF_TX_PWR_0dBm=3
+typedef enum {
+    NRF_TX_PWR_M18dBm     = 0,
+    NRF_TX_PWR_M12dBm     = 1,
+    NRF_TX_PWR_M6dBm      = 2,
+    NRF_TX_PWR_0dBm       = 3
 } NRF_TX_PWR;
 
-typedef enum{
-	NRF_ADDR_WIDTH_3=1,
-	NRF_ADDR_WIDTH_4=2,
-	NRF_ADDR_WIDTH_5=3
+typedef enum {
+    NRF_ADDR_WIDTH_3      = 1,
+    NRF_ADDR_WIDTH_4      = 2,
+    NRF_ADDR_WIDTH_5      = 3
 } NRF_ADDR_WIDTH;
 
-typedef enum{
-	NRF_CRC_WIDTH_1B=0,
-	NRF_CRC_WIDTH_2B=1
+typedef enum {
+    NRF_CRC_WIDTH_1B      = 0,
+    NRF_CRC_WIDTH_2B      = 1
 } NRF_CRC_WIDTH;
 
 typedef enum{
-	NRF_STATE_RX=1,
-	NRF_STATE_TX=0
+    NRF_STATE_RX          = 1,
+    NRF_STATE_TX          = 0
 } NRF_TXRX_STATE;
 
-typedef struct{
-	SPI_HandleTypeDef* spi;
-	NRF_DATA_RATE 	DATA_RATE;
-	uint8_t			RF_CHANNEL;
-	uint8_t			PayloadLength;
-	uint8_t			RetransmitCount;
-	uint8_t			RetransmitDelay;
-	NRF_TX_PWR		TX_POWER;
-	uint8_t*		RX_ADDRESS;
-	uint8_t*		TX_ADDRESS;
-	NRF_CRC_WIDTH	CRC_WIDTH;
-	NRF_ADDR_WIDTH	ADDR_WIDTH;
-	NRF_TXRX_STATE	STATE;
-	uint8_t			BUSY_FLAG;
+typedef struct {
+    SPI_HandleTypeDef* 	spi;
+    NRF_DATA_RATE 		DATA_RATE;
+    uint8_t				RF_CHANNEL;
+    uint8_t				PayloadLength;
+    uint8_t				RetransmitCount;
+    uint8_t				RetransmitDelay;
+    NRF_TX_PWR			TX_POWER;
+    uint8_t*			RX_ADDRESS;
+    uint8_t*			TX_ADDRESS;
+    NRF_CRC_WIDTH		CRC_WIDTH;
+    NRF_ADDR_WIDTH		ADDR_WIDTH;
+    NRF_TXRX_STATE		STATE;
+    uint8_t				BUSY_FLAG;
 
-	uint8_t*		RX_BUFFER;
-	uint8_t*		TX_BUFFER;
+    uint8_t*			RX_BUFFER;
+    uint8_t*			TX_BUFFER;
 
-	GPIO_TypeDef*	NRF_CSN_GPIOx;	// CSN pin
-	uint16_t		NRF_CSN_GPIO_PIN;
+    GPIO_TypeDef*		NRF_CSN_GPIOx;	// CSN pin
+    uint16_t			NRF_CSN_GPIO_PIN;
 
-	GPIO_TypeDef*	NRF_CE_GPIOx;	// CE pin
-	uint16_t		NRF_CE_GPIO_PIN;
+    GPIO_TypeDef*		NRF_CE_GPIOx;	// CE pin
+    uint16_t			NRF_CE_GPIO_PIN;
 
-	GPIO_TypeDef*	NRF_IRQ_GPIOx;	// IRQ pin
-	uint16_t		NRF_IRQ_GPIO_PIN;
-	IRQn_Type		NRF_IRQn;
-	uint8_t			NRF_IRQ_preempt_priority;
-	uint8_t			NRF_IRQ_sub_priority;
+    GPIO_TypeDef*		NRF_IRQ_GPIOx;	// IRQ pin
+    uint16_t			NRF_IRQ_GPIO_PIN;
+    IRQn_Type			NRF_IRQn;
+    uint8_t				NRF_IRQ_preempt_priority;
+    uint8_t				NRF_IRQ_sub_priority;
 
 } NRF24L01;
 
-typedef enum{
-	NRF_OK,
-	NRF_ERROR
+typedef enum {
+    NRF_OK,
+    NRF_ERROR
 } NRF_RESULT;
 
 


### PR DESCRIPTION
- Rename
Rename Typedef struct NRF24L01 -> nrf24L01_Dev, it's safer which is difficult to find duplication of names.
Rename GPIO opra function, Enable/Disable makes me confused.
- Addition
Add some Comment of nrf24L01_Dev. It can help user understand meanings of this parameter.
- Fix
There is some Code Format mass.