### PR TITLE
Async packet receiving, fixed AA and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,38 @@ NRF24L01 modules interface directly over SPI and two additional wires (CE, IRQ).
 
 ## Software Setup
 Fill out all the parameters in the `nrf24l01_config` structure and call
-`nrf_init` to initialize your `nrf24l01` structure. This structure can then be
+`nrf_init` to initialize your `nrf24l01` structure. This structure can then be 
 used to make subsequent library calls.
+
+## Important Functions
+
+### EXTI Interrupt Handler
+* `void nrf_irq_handler(nrf24l01* dev)` 
+
+  You must call this function on Falling edge trigger detection interrupt handler, typically, from `HAL_GPIO_EXTI_Callback`
+
+### Asynchronous Data Receiving
+* `void nrf_packet_received_callback(nrf24l01* dev, uint8_t* data)`
+
+  Override this function (it is `__weak` by default) to handle received data asynchronously,
+default implementation is used in favor of `nrf_receive_packet` for blocking data receiving 
+
+### Blocking Data Receiving
+* `const uint8_t* nrf_receive_packet(nrf24l01* dev)`
+ 
+  Blocks until the data has arrived, then returns a pointer to received data. Please note, once `nrf_packet_received_callback` routine is overridden, this one will stop working.
+
+### Blocking Data Sending
+* `NRF_RESULT nrf_send_packet(nrf24l01* dev, const uint8_t* data)` 
+
+  If the Auto Acknowledgement is enabled (default), this method will return `NRF_OK`, if the data has been acknowledged by other party, and `NRF_ERROR` if the data has not been received (maximum retransmissions has occurred). 
+  
+  If the AA is disabled, returns `NRF_OK` once the data has been transmitted (with no guarantee the data was actually received). 
+
+### Blocking Data Sending, with NO_ACK flag
+* `NRF_RESULT nrf_send_packet_noack(nrf24l01* dev, const uint8_t* data)` 
+
+  Disables the AA for this packet, thus this method always returns `NRF_OK`.
 
 ## Requirements
 For building you will need:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Library for interfacing with NRF24L01(+) modules from an STM32 micro.
  - CI setup
 
 ## Hardware Setup
-NRF24L01 modules interface directly over SPI and two additional wires (CE, IRQ).
+NRF24L01 modules interface directly over SPI and three additional wires (CE, CSN and IRQ).
 
 ## Software Setup
 Fill out all the parameters in the `nrf24l01_config` structure and call

--- a/inc/nrf24l01.h
+++ b/inc/nrf24l01.h
@@ -211,7 +211,7 @@ NRF_RESULT nrf_enable_max_retransmit_irq(nrf24l01* dev, bool activate);
 NRF_RESULT nrf_set_rx_address_p0(nrf24l01* dev,
                                  uint8_t*  address); // 5bytes of address
 
-/* RX_ADDR_P0 */
+/* RX_ADDR_P1 */
 NRF_RESULT nrf_set_rx_address_p1(nrf24l01* dev,
                                  uint8_t*  address); // 5bytes of address
 
@@ -222,5 +222,5 @@ NRF_RESULT nrf_set_tx_address(nrf24l01* dev,
 /* RX_PW_P0 */
 NRF_RESULT nrf_set_rx_payload_width_p0(nrf24l01* dev, uint8_t width);
 
-/* RX_PW_P0 */
+/* RX_PW_P1 */
 NRF_RESULT nrf_set_rx_payload_width_p1(nrf24l01* dev, uint8_t width);

--- a/inc/nrf24l01.h
+++ b/inc/nrf24l01.h
@@ -96,6 +96,9 @@ typedef struct {
     uint8_t* rx_address;
     uint8_t* tx_address;
 
+    /* Must be sufficient size according to payload_length */
+    uint8_t* rx_buffer;
+
     SPI_HandleTypeDef* spi;
     uint32_t           spi_timeout;
 
@@ -113,7 +116,9 @@ typedef struct {
 typedef struct {
     nrf24l01_config config;
 
-    volatile uint8_t        busy;
+    volatile uint8_t        tx_busy;
+    volatile NRF_RESULT     tx_result;
+    volatile uint8_t        rx_busy;
     volatile NRF_TXRX_STATE state;
 
     /* Receive Buffer, see nrf_irq_handler */
@@ -123,26 +128,50 @@ typedef struct {
 /* Initialization routine */
 NRF_RESULT nrf_init(nrf24l01* dev, nrf24l01_config* config);
 
-/* EXTI Interrupt Handler */
+/* EXTI Interrupt Handler
+ *
+ * You must call this function on Falling edge trigger detection interrupt handler,
+ * typically, from HAL_GPIO_EXTI_Callback  */
 void nrf_irq_handler(nrf24l01* dev);
 
-/* Blocking Data Sending */
-NRF_RESULT nrf_send_packet(nrf24l01* dev, uint8_t* data);
+/* Asynchronous Data Receiving (__weak)
+ *
+ * Override this function to handle received data asynchronously,
+ * default implementation is used in favor of nrf_receive_packet for blocking data receiving */
+void nrf_packet_received_callback(nrf24l01* dev, uint8_t* data);
+
+/* Blocking Data Receiving
+ *
+ * Blocks until the data has arrived, then returns a pointer to received data.
+ * Please note, once nrf_packet_received_callback routine is overridden, this one will stop working. */
+const uint8_t* nrf_receive_packet(nrf24l01* dev);
+
+/* Blocking Data Sending
+ *
+ * If the AA is enabled (default), this method will return:
+ *   NRF_OK - the data has been acknowledged by other party
+ *   NRF_ERROR - the data has not been received (maximum retransmissions has occurred)
+ * If the AA is disabled, returns NRF_OK once the data has been transmitted
+ *   (with no guarantee the data was actually received). */
+NRF_RESULT nrf_send_packet(nrf24l01* dev, const uint8_t* data);
+
+/* Blocking Data Sending, with NO_ACK flag
+ *
+ * Disables the AA for this packet, thus this method always returns NRF_OK */
+NRF_RESULT nrf_send_packet_noack(nrf24l01* dev, const uint8_t* data);
 
 /* Non-Blocking Data Sending */
-NRF_RESULT nrf_push_packet(nrf24l01* dev, uint8_t* data);
-
-/* Override this function to handle received data */
-__weak void nrf_packet_received(uint8_t* data);
+NRF_RESULT nrf_push_packet(nrf24l01* dev, const uint8_t* data);
 
 /* LOW LEVEL STUFF (you don't have to look in here...)*/
-NRF_RESULT nrf_send_command(nrf24l01* dev, NRF_COMMAND cmd, uint8_t* tx,
+NRF_RESULT nrf_send_command(nrf24l01* dev, NRF_COMMAND cmd, const uint8_t* tx,
                             uint8_t* rx, uint8_t len);
 /* CMD */
 NRF_RESULT nrf_read_register(nrf24l01* dev, uint8_t reg, uint8_t* data);
 NRF_RESULT nrf_write_register(nrf24l01* dev, uint8_t reg, uint8_t* data);
 NRF_RESULT nrf_read_rx_payload(nrf24l01* dev, uint8_t* data);
-NRF_RESULT nrf_write_tx_payload(nrf24l01* dev, uint8_t* data);
+NRF_RESULT nrf_write_tx_payload(nrf24l01* dev, const uint8_t* data);
+NRF_RESULT nrf_write_tx_payload_noack(nrf24l01* dev, const uint8_t* data);
 NRF_RESULT nrf_flush_rx(nrf24l01* dev);
 NRF_RESULT nrf_flush_tx(nrf24l01* dev);
 
@@ -165,8 +194,7 @@ NRF_RESULT nrf_set_retransmittion_delay(nrf24l01* dev, uint8_t delay);
 NRF_RESULT nrf_set_address_width(nrf24l01* dev, NRF_ADDR_WIDTH width);
 
 /* EN_RXADDR */
-NRF_RESULT nrf_enable_rx_pipe(nrf24l01* dev, uint8_t pipe);
-// TODO disable pipe?
+NRF_RESULT nrf_enable_rx_pipes(nrf24l01* dev, uint8_t pipes);
 
 /* EN_AA */
 NRF_RESULT nrf_enable_auto_ack(nrf24l01* dev, uint8_t pipe);
@@ -185,9 +213,16 @@ NRF_RESULT nrf_enable_max_retransmit_irq(nrf24l01* dev, bool activate);
 NRF_RESULT nrf_set_rx_address_p0(nrf24l01* dev,
                                  uint8_t*  address); // 5bytes of address
 
+/* RX_ADDR_P0 */
+NRF_RESULT nrf_set_rx_address_p1(nrf24l01* dev,
+                                 uint8_t*  address); // 5bytes of address
+
 /* TX_ADDR */
 NRF_RESULT nrf_set_tx_address(nrf24l01* dev,
                               uint8_t*  address); // 5bytes of address
 
 /* RX_PW_P0 */
 NRF_RESULT nrf_set_rx_payload_width_p0(nrf24l01* dev, uint8_t width);
+
+/* RX_PW_P0 */
+NRF_RESULT nrf_set_rx_payload_width_p1(nrf24l01* dev, uint8_t width);

--- a/inc/nrf24l01.h
+++ b/inc/nrf24l01.h
@@ -121,8 +121,6 @@ typedef struct {
     volatile uint8_t        rx_busy;
     volatile NRF_TXRX_STATE state;
 
-    /* Receive Buffer, see nrf_irq_handler */
-    uint8_t* rx_buffer;
 } nrf24l01;
 
 /* Initialization routine */

--- a/inc/nrf24l01.h
+++ b/inc/nrf24l01.h
@@ -194,7 +194,7 @@ NRF_RESULT nrf_set_retransmittion_delay(nrf24l01* dev, uint8_t delay);
 NRF_RESULT nrf_set_address_width(nrf24l01* dev, NRF_ADDR_WIDTH width);
 
 /* EN_RXADDR */
-NRF_RESULT nrf_enable_rx_pipes(nrf24l01* dev, uint8_t pipes);
+NRF_RESULT nrf_set_rx_pipes(nrf24l01* dev, uint8_t pipes);
 
 /* EN_AA */
 NRF_RESULT nrf_enable_auto_ack(nrf24l01* dev, uint8_t pipe);

--- a/inc/nrf24l01.h
+++ b/inc/nrf24l01.h
@@ -99,6 +99,9 @@ typedef struct {
     SPI_HandleTypeDef* spi;
     uint32_t           spi_timeout;
 
+    GPIO_TypeDef* csn_port;
+    uint16_t      csn_pin;
+
     GPIO_TypeDef* ce_port;
     uint16_t      ce_pin;
 
@@ -113,9 +116,8 @@ typedef struct {
     volatile uint8_t        busy;
     volatile NRF_TXRX_STATE state;
 
-    /* RX/TX Buffer */
+    /* Receive Buffer, see nrf_irq_handler */
     uint8_t* rx_buffer;
-    uint8_t* tx_buffer;
 } nrf24l01;
 
 /* Initialization routine */
@@ -124,13 +126,14 @@ NRF_RESULT nrf_init(nrf24l01* dev, nrf24l01_config* config);
 /* EXTI Interrupt Handler */
 void nrf_irq_handler(nrf24l01* dev);
 
-/* Blocking Data Sending / Receiving FXs */
+/* Blocking Data Sending */
 NRF_RESULT nrf_send_packet(nrf24l01* dev, uint8_t* data);
-NRF_RESULT nrf_receive_packet(nrf24l01* dev, uint8_t* data);
 
-/* Non-Blocking Data Sending / Receiving FXs */
+/* Non-Blocking Data Sending */
 NRF_RESULT nrf_push_packet(nrf24l01* dev, uint8_t* data);
-NRF_RESULT nrf_pull_packet(nrf24l01* dev, uint8_t* data);
+
+/* Override this function to handle received data */
+__weak void nrf_packet_received(uint8_t* data);
 
 /* LOW LEVEL STUFF (you don't have to look in here...)*/
 NRF_RESULT nrf_send_command(nrf24l01* dev, NRF_COMMAND cmd, uint8_t* tx,

--- a/src/nrf24l01.c
+++ b/src/nrf24l01.c
@@ -48,7 +48,7 @@ NRF_RESULT nrf_init(nrf24l01* dev, nrf24l01_config* config) {
     nrf_set_retransmittion_count(dev, dev->config.retransmit_count);
     nrf_set_retransmittion_delay(dev, dev->config.retransmit_delay);
 
-    nrf_enable_rx_pipes(dev, 0x03);
+    nrf_set_rx_pipes(dev, 0x03);
     nrf_enable_auto_ack(dev, 0);
 
     nrf_clear_interrupts(dev);
@@ -335,7 +335,7 @@ NRF_RESULT nrf_set_address_width(nrf24l01* dev, NRF_ADDR_WIDTH width) {
     return NRF_OK;
 }
 
-NRF_RESULT nrf_enable_rx_pipes(nrf24l01* dev, uint8_t pipes) {
+NRF_RESULT nrf_set_rx_pipes(nrf24l01* dev, uint8_t pipes) {
     if (nrf_write_register(dev, NRF_EN_RXADDR, &pipes) != NRF_OK) {
         return NRF_ERROR;
     }

--- a/src/nrf24l01.c
+++ b/src/nrf24l01.c
@@ -18,7 +18,6 @@ static void csn_reset(nrf24l01* dev) {
 
 NRF_RESULT nrf_init(nrf24l01* dev, nrf24l01_config* config) {
     dev->config = *config;
-    dev->rx_buffer = dev->config.rx_buffer;
 
     ce_reset(dev);
     csn_reset(dev);
@@ -97,11 +96,12 @@ void nrf_irq_handler(nrf24l01* dev) {
         nrf_write_register(dev, NRF_STATUS, &status);
         nrf_read_register(dev, NRF_FIFO_STATUS, &fifo_status);
         if ((fifo_status & 1) == 0) {
-            nrf_read_rx_payload(dev, dev->rx_buffer);
+        	uint8_t* rx_buffer = dev->config.rx_buffer;
+            nrf_read_rx_payload(dev, rx_buffer);
             status |= 1 << 6;
             nrf_write_register(dev, NRF_STATUS, &status);
             // nrf_flush_rx(dev);
-            nrf_packet_received_callback(dev, dev->rx_buffer);
+            nrf_packet_received_callback(dev, rx_buffer);
         }
         ce_set(dev);
     }
@@ -565,7 +565,7 @@ const uint8_t* nrf_receive_packet(nrf24l01* dev) {
 
     while (dev->rx_busy == 1) {} // wait for reception
 
-    return dev->rx_buffer;
+    return dev->config.rx_buffer;
 }
 
 NRF_RESULT nrf_push_packet(nrf24l01* dev, const uint8_t* data) {

--- a/src/nrf24l01.c
+++ b/src/nrf24l01.c
@@ -96,7 +96,7 @@ void nrf_irq_handler(nrf24l01* dev) {
         nrf_write_register(dev, NRF_STATUS, &status);
         nrf_read_register(dev, NRF_FIFO_STATUS, &fifo_status);
         if ((fifo_status & 1) == 0) {
-        	uint8_t* rx_buffer = dev->config.rx_buffer;
+            uint8_t* rx_buffer = dev->config.rx_buffer;
             nrf_read_rx_payload(dev, rx_buffer);
             status |= 1 << 6;
             nrf_write_register(dev, NRF_STATUS, &status);


### PR DESCRIPTION
This pull request:

* Fixes AA as it was not working at all with bidirectional communication;
* `nrf_send_packet` now returns `NRF_OK` if the packet was actually delivered (AA);
* You can receive packets in async way with `nrf_packet_received_callback` and in blocking way with `nrf_receive_packet`;
* Added documentation to cover all that.